### PR TITLE
Fixed Footer year of Registration page

### DIFF
--- a/registration.html
+++ b/registration.html
@@ -304,7 +304,7 @@
 
     <footer class="cosmic-footer">
         <div class="footer-bottom">
-            <p>&copy; 2025 ClubsDSCE. All rights reserved.</p>
+            <p>&copy; <span id="year"></span> ClubsDSCE. All rights reserved.</p>
         </div>
     </footer>
 


### PR DESCRIPTION
### Summary
This PR updates the footer to automatically display the current year.

### Context
The footer year was previously hardcoded, which requires manual updates.  
A small inline script to handle this dynamically was missed in an earlier PR.

### Change Details
- Replaced the static year with a `span` element.
- Added a lightweight JavaScript snippet to set the current year on page load.

### Impact
- Improves maintainability
- No functional or behavioral changes
- Safe, non-breaking UI update

Thank you for reviewing.

### Screenshot of Output
<img width="1366" height="647" alt="Screenshot (29)" src="https://github.com/user-attachments/assets/7dc2e8cd-702f-4862-9f6c-f53b45ccba6a" />
