### PR TITLE
fix: make year-of-study dropdown options visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -793,6 +793,12 @@ img {
     transition: var(--transition);
 }
 
+/* Fix: Year of Study dropdown option visibility */
+.form-group select option {
+    color: #2d3436;
+    background-color: #ffffff;
+}
+
 .form-group input:focus,
 .form-group select:focus,
 .form-group textarea:focus {


### PR DESCRIPTION
### Summary
Fixed an issue where the "Year of Study" dropdown options were not visible when opened due to insufficient text/background contrast.

### Fix
Explicitly styled the `option` elements inside `.form-group select` to ensure readability when the dropdown opens.

Fixes #25
