### PR TITLE
fix: unify branding to "DSCE Clubs" and correct typos (#52) 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# 🤝 Contributing to ClubHub
+# 🤝 Contributing to DSCE Clubs
 
-First of all, thank you for taking the time to contribute to **ClubHub** 🎉  
+First of all, thank you for taking the time to contribute to **DSCE Clubs** 🎉  
 Your contributions help improve the project’s quality, usability, and community impact.
 
 This document provides clear guidelines to ensure a smooth and effective contribution process for everyone.
@@ -9,7 +9,7 @@ This document provides clear guidelines to ensure a smooth and effective contrib
 
 ## 📌 About the Project
 
-**ClubHub** is a centralized platform designed to streamline club management, event coordination, and communication within educational institutions.
+**DSCE Clubs** is a centralized platform designed to streamline club management, event coordination, and communication within educational institutions.
 
 The project is actively developed under **Social Winter of Code (SWoC) 2026** and welcomes meaningful open-source contributions.
 
@@ -127,7 +127,7 @@ By contributing to this repository, you agree that your contributions will be li
 
 ---
 ## 🙌 Acknowledgements
-Thank you for contributing to ClubHub and supporting open-source development through SWoC 2026.
+Thank you for contributing to DSCE Clubs and supporting open-source development through SWoC 2026.
 Your efforts are truly appreciated!
 
 Happy Contributing 🚀

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🎓 ClubHub  
+# 🎓 DSCE Clubs  
 ### Centralized Club Management Platform
 
 <p align="center">
@@ -19,7 +19,7 @@ A modern, lightweight, and open-source web platform for managing clubs, events, 
 
 ## 📖 About The Project
 
-**ClubHub** is a centralized, web-based platform designed to simplify **club management, event coordination, and campus communication** within educational institutions.
+**DSCE Clubs** is a centralized, web-based platform designed to simplify **club management, event coordination, and campus communication** within educational institutions.
 
 It offers a **single, unified interface** for students, club leads, and faculty administrators—ensuring transparency, accessibility, and smooth coordination of campus activities.
 
@@ -36,7 +36,7 @@ Educational institutions often face:
 
 ### ✅ Solution
 
-**ClubHub** brings all club-related activities under **one structured, accessible, and transparent system**.
+**DSCE Clubs** brings all club-related activities under **one structured, accessible, and transparent system**.
 
 ---
 
@@ -148,7 +148,7 @@ We welcome contributions from all experience levels 💙
 
 ## 🧑‍🤝‍🧑 Contributors
 
-Thanks to all the amazing people who have contributed to **ClubHub** 💙
+Thanks to all the amazing people who have contributed to **DSCE Clubs** 💙
 
 <a href="https://github.com/abhishree-k/club-hub/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=abhishree-k/club-hub" />

--- a/events.html
+++ b/events.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Events | DSCEClubs</title>
+    <title>Events | DSCE Clubs</title>
     <link rel="stylesheet" href="style.css">
     <link
         href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Playfair+Display:wght@700&display=swap"
@@ -18,7 +18,7 @@
     <nav class="cosmic-nav">
         <div class="nav-logo">
             <span class="logo-icon">🌌</span>
-            <span class="logo-text">DSCEClubs</span>
+            <span class="logo-text">DSCE Clubs</span>
         </div>
         <ul class="nav-links">
             <li><a href="index.html">Home</a></li>
@@ -67,15 +67,15 @@
             <div class="calendar-legend">
                 <div class="legend-item">
                     <span class="legend-color tech"></span>
-                    <span>Tech Society- POINT BLANK</span>
+                    <span>Tech Society - POINT BLANK</span>
                 </div>
                 <div class="legend-item">
                     <span class="legend-color arts"></span>
-                    <span>Creative Arts- AALEKA</span>
+                    <span>Creative Arts - AALEKA</span>
                 </div>
                 <div class="legend-item">
                     <span class="legend-color debate"></span>
-                    <span>Debate Club- LITSOC</span>
+                    <span>Debate Club - LITSOC</span>
                 </div>
                 <div class="legend-item">
                     <span class="legend-color music"></span>
@@ -87,7 +87,7 @@
                 </div>
                 <div class="legend-item">
                     <span class="legend-color science"></span>
-                    <span>Dnace Club- ABCD</span>
+                    <span>Dance Club - ABCD</span>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>College Club Hub</title>
+    <title>Home | DSCE Clubs</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
@@ -14,7 +14,7 @@
     <nav class="cosmic-nav">
         <div class="nav-logo">
             <span class="logo-icon">🌌</span>
-            <span class="logo-text">DSCE CLUBS!!</span>
+            <span class="logo-text">DSCE Clubs</span>
         </div>
         <ul class="nav-links">
             <li><a href="index.html" class="active">Home</a></li>
@@ -52,7 +52,7 @@
             <div class="clubs-grid">
                 <div class="club-card" data-club="tech">
                     <div class="club-icon">💻</div>
-                    <h3>Tech Society- POINT BLANK </h3>
+                    <h3>Tech Society - POINT BLANK</h3>
                     <p>Innovate, code, and build the future with fellow tech enthusiasts.</p>
                     <div class="club-tags">
                         <span>Hackathons</span>
@@ -64,19 +64,19 @@
                 
                 <div class="club-card" data-club="arts">
                     <div class="club-icon">🎨</div>
-                    <h3>Creative Arts-AALEKA</h3>
+                    <h3>Creative Arts - AALEKA</h3>
                     <p>Express yourself through painting, sculpture, and digital art.</p>
                     <div class="club-tags">
                         <span>Exhibitions</span>
                         <span>Live Demos</span>
                         <span>Collaborations</span>
-                        <span>Competitionss</span>
+                        <span>Competitions</span>
                     </div>
                 </div>
                 
                 <div class="club-card" data-club="debate">
                     <div class="club-icon">💬</div>
-                    <h3>Debate Club- LITSOC</h3>
+                    <h3>Debate Club - LITSOC</h3>
                     <p>Sharpen your rhetoric and critical thinking skills.</p>
                     <div class="club-tags">
                         <span>Tournaments</span>
@@ -87,7 +87,7 @@
                 
                 <div class="club-card" data-club="music">
                     <div class="club-icon">🎵</div>
-                    <h3>Music Society- </h3>
+                    <h3>Music Society</h3>
                     <p>Create, perform, and appreciate music in all its forms.</p>
                     <div class="club-tags">
                         <span>Concerts</span>
@@ -110,7 +110,7 @@
                 
                 <div class="club-card" data-club="science">
                     <div class="club-icon">💃</div>
-                    <h3>Dance club- ABCD </h3>
+                    <h3>Dance Club - ABCD</h3>
                     <p>"Let's move to the beat and make memories together!".</p>
                     <div class="club-tags">
                         <span>Live Performances</span>
@@ -149,7 +149,7 @@
         <div class="footer-content">
             <div class="footer-logo">
                 <span class="logo-icon">🌌</span>
-                <span class="logo-text">DSCE</span>
+                <span class="logo-text">DSCE Clubs</span>
             </div>
             <div class="footer-links">
                 <div class="footer-column">
@@ -179,7 +179,7 @@
             </div>
         </div>
         <div class="footer-bottom">
-            <p>&copy; <span id="year"></span> ClubsDSCE. All rights reserved.</p>
+            <p>&copy; <span id="year"></span> DSCE Clubs. All rights reserved.</p>
         </div>
     </footer>
 

--- a/my-hub.html
+++ b/my-hub.html
@@ -131,7 +131,7 @@
 
     <footer class="cosmic-footer">
         <div class="footer-bottom">
-            <p>&copy; 2025 ClubsDSCE. All rights reserved.</p>
+            <p>&copy; 2025 DSCE Clubs. All rights reserved.</p>
         </div>
     </footer>
 

--- a/past-events.html
+++ b/past-events.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Past Events | DSCEClubs</title>
+    <title>Past Events | DSCE Clubs</title>
     <link rel="stylesheet" href="style.css">
     <link
         href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Playfair+Display:wght@700&display=swap"

--- a/registration.html
+++ b/registration.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Registration |DSCE Clubs</title>
+    <title>Registration | DSCE Clubs</title>
     <link rel="stylesheet" href="style.css">
     <link
         href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Playfair+Display:wght@700&display=swap"
@@ -137,7 +137,7 @@
                                 <input type="checkbox" name="club" value="sports">
                                 <span class="checkmark"></span>
                             </label>
-                            <label class="checkbox-container">Dance club
+                            <label class="checkbox-container">Dance Club
                                 <input type="checkbox" name="club" value="science">
                                 <span class="checkmark"></span>
                             </label>
@@ -304,7 +304,7 @@
 
     <footer class="cosmic-footer">
         <div class="footer-bottom">
-            <p>&copy; <span id="year"></span> ClubsDSCE. All rights reserved.</p>
+            <p>&copy; <span id="year"></span> DSCE Clubs. All rights reserved.</p>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary:

This PR standardizes site branding to "DSCE Clubs", fixes typos (e.g., Competitionss → Competitions), removes stray trailing punctuation (e.g., !!), and normalizes capitalization/spacing across pages and docs. 
These are text-only, non-breaking changes to improve consistency and UX.

## Fixes: Fixes #52

### What I changed


- Standardized site name to DSCE Clubs everywhere (titles, nav, footer, meta).
- Fixed typo Competitionss → Competitions.
- Removed trailing punctuation and inconsistent capitalization (examples: DSCE CLUBS!! → DSCE Clubs, ClubsDSCE → DSCE Clubs).
- Normalized club name spacing/capitalization (e.g., Tech Society - POINT BLANK, Creative Arts - AALEKA, Dance Club - ABCD).
- Updated docs to reflect branding README.md, CONTRIBUTING.md.

### Files modified


- index.html
- registration.html
- events.html
- past-events.html
- my-hub.html
- README.md
- CONTRIBUTING.md

## Notes for reviewers / QA checklist

-  Confirm visual screenshots for [index.html], [registration.html], and [README.md] are attached to the PR.

###  📸
before:
<img width="1919" height="976" alt="image" src="https://github.com/user-attachments/assets/ee41a267-901d-4e53-af96-e4761dfbbdbd" />

after:
<img width="1919" height="989" alt="image" src="https://github.com/user-attachments/assets/12a88d5c-41a4-4cb4-adb9-3b87984ba421" />
 

-  Run a quick repo-wide search for Competitionss, ClubsDSCE, DSCE CLUBS!!, and ClubHub to confirm no remaining instances.

-  Verify no HTML structure or JS behavior was changed unintentionally (these were text-only edits). 🔧


@abhishree-k please review 
