### PR TITLE
Fix-Readme-Broken-images-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Educational institutions often face:
 
 ## 🖼️ Screenshots
 
-![Home Page](assets/screenshots/home.png)
-![Clubs Page](assets/screenshots/clubs.png)
-![View Club](assets/screenshots/view-club.png)
+![Home Page](assets/screenshots/home_page.png)
+![Clubs Page](assets/screenshots/club.png)
+![View Club](assets/screenshots/view_club.png)
 
 ---
 


### PR DESCRIPTION
This PR fixes #162 



In Readme.md file the images represented in the document were not visible and broken images icons were appearing because of incorrect links. 

I have corrected it and now proper linkages are given so the images are clearly visible in documentation.


Hii @abhishree-k 
Please look in to it and let me know if you need any changes , also please label SWOC'26. 
Thank You 

