### PR TITLE
[Feature]: Automate Post-Assignment Workflow and Stale Issue Management

### DIFF
--- a/.github/workflows/issue-ops.yml
+++ b/.github/workflows/issue-ops.yml
@@ -25,17 +25,38 @@ jobs:
             if (eventName === 'issues' && payload.action === 'assigned') {
                const assignee = payload.assignee.login;
                
-               // Add labels 'in-progress' and 'assigned'
-               try {
-                 await github.rest.issues.addLabels({
-                   owner: context.repo.owner,
-                   repo: context.repo.repo,
-                   issue_number: issue.number,
-                   labels: ['in-progress', 'assigned']
-                 });
-               } catch (e) {
-                 console.log('Could not add labels.');
-               }
+                // Ensure 'in-progress' label exists with correct color
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: 'in-progress',
+                    color: '69c71c',
+                    description: 'Issue is currently being worked on'
+                  });
+                } catch (e) {
+                  // Label exists, update color to match preference
+                  try {
+                    await github.rest.issues.updateLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: 'in-progress',
+                      color: '69c71c'
+                    });
+                  } catch (u) { console.log('Label update skipped.'); }
+                }
+
+                // Add label 'in-progress'
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['in-progress']
+                  });
+                } catch (e) {
+                  console.log('Could not add label.');
+                }
 
                // Post Welcome Comment
                await github.rest.issues.createComment({
@@ -54,7 +75,7 @@ jobs:
                // Only remove labels if NO assignees are left 
                // (This prevents removing labels if one of multiple people is removed)
                if (issue.assignees.length === 0) {
-                  const labelsToRemove = ['in-progress', 'assigned'];
+                  const labelsToRemove = ['in-progress'];
                   for (const label of labelsToRemove) {
                     try {
                       await github.rest.issues.removeLabel({
@@ -103,7 +124,7 @@ jobs:
                });
 
                // Remove Labels
-               const labelsToRemove = ['in-progress', 'assigned'];
+               const labelsToRemove = ['in-progress'];
                for (const label of labelsToRemove) {
                  try {
                    await github.rest.issues.removeLabel({

--- a/.github/workflows/stale-claim.yml
+++ b/.github/workflows/stale-claim.yml
@@ -88,7 +88,7 @@ jobs:
                          assignees: users
                        });
                        
-                       const labelsToRemove = ['in-progress', 'assigned'];
+                       const labelsToRemove = ['in-progress'];
                        for (const label of labelsToRemove) {
                          try {
                             await github.rest.issues.removeLabel({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Please follow the standard GitHub workflow outlined below:
 - Look for an issue that interests you and isn't already assigned.
 - Comment on the issue asking to be assigned (e.g., "I'd like to work on this").
 - **Wait for a maintainer** to assign you.
-- Once assigned, the system will automatically tag the issue as `in-progress` and `assigned`.
+- Once assigned, the system will automatically tag the issue as `in-progress`.
 - **Note**: Claims expire after **14 days** of inactivity.
 - To release an issue, comment `/unclaim` or `/unassign`.
 


### PR DESCRIPTION
- closes #156 

## Description
This PR adds GitHub Actions workflows to improve issue management after a contributor is assigned.  
**Important:** Assignment itself is manual. The bot only reacts once a maintainer assigns someone.  

These workflows handle labeling, reminders, and cleanup automatically, reducing manual tracking and keeping issues moving.  

## Changes Made

### 1. issue-ops.yml (The "Live Manager")
- Reacts instantly to events after a maintainer assigns a user.  
- Adds `in-progress`  label automatically.  
- Posts a welcome comment letting the contributor know they have 14 days to complete the task.  
- Allows assignees to unassign themselves by commenting `/unclaim` or `/unassign` at the start of a comment.  
- Ignores commands not at the start (e.g., “Please don’t /unclaim me”).  

### 2. stale-claim.yml (The "Clock Watcher")
- Runs every 6 hours to monitor issues for inactivity.  
- Sends a friendly reminder if an issue hasn’t been updated for 7 days.  
- Tags the assignee to ask for a status update.  
- Resets the 14-day timer if the contributor responds to the reminder.  
- Clears the assignee and labels after 14 days of no response and posts a message that the claim has expired.  

## Workflow Summary
1. **Manual Assignment:** Maintainer assigns a contributor via GitHub.  
2. **Bot Actions:** Adds labels, posts a welcome comment, and tracks progress.  
3. **7-Day Reminder:** Bot nudges inactive contributors for a status update.  
4. **14-Day Cleanup:** Bot clears assignee and labels if there’s no response.  

## Impact / Benefits
- Reduces manual intervention by maintainers.  
- Keeps contributors accountable and issues moving.  
- Prevents tasks from stalling due to inactivity.  
- Automates post-assignment workflow: labeling → reminder → unassignment → reopening.  

### This pull request is submitted as part of SWOC 2026. Thank you for taking the time to review it.