### PR TITLE
Add forgot password page for password reset feature

### DIFF
--- a/forgot-password.html
+++ b/forgot-password.html
@@ -15,19 +15,39 @@
 
 <body>
   <div class="stars-background"></div>
-  <nav class="cosmic-nav">
+  <nav class="cosmic-nav" role="navigation" aria-label="Main navigation">
     <div class="nav-logo">
       <span class="logo-icon">🌌</span>
       <span class="logo-text">DSCE Clubs</span>
     </div>
-    <ul class="nav-links">
+    <ul class="nav-links" id="nav-links" aria-hidden="false">
       <li><a href="index.html">Home</a></li>
+      <li><a href="events.html">Live & Upcoming Events</a></li>
+      <li><a href="past-events.html">Past Events</a></li>
+      <li><a href="faq.html">FAQ</a></li>
+      <li><a href="registration.html">Registration</a></li>
+      <li id="nav-my-hub" class="hidden"><a href="my-hub.html">My Hub</a></li>
+      <li><a href="admin-login.html">Admin</a></li>
+      <li id="nav-login">
+        <a href="registration.html#student-login">Student Login</a>
+      </li>
+      <li id="nav-logout" class="hidden">
+        <a href="#" id="student-logout-btn">Logout</a>
+      </li>
       <li>
         <button id="theme-switch" class="theme-btn" aria-label="Toggle Dark Mode">
-          <i class="fas fa-meteor"></i>
+          <i class="fas fa-moon"></i>
         </button>
       </li>
     </ul>
+    <button class="mobile-menu-toggle nav-hamburger" aria-label="Toggle navigation menu" aria-expanded="false"
+      aria-controls="nav-links" type="button">
+      <span class="hamburger-icon" aria-hidden="true">
+        <span class="line"></span>
+        <span class="line"></span>
+        <span class="line"></span>
+      </span>
+    </button>
   </nav>
 
   <div class="login-container">


### PR DESCRIPTION
Changes
 Added forgot-password.html with email input form
 Matches existing design system (cosmic theme, same navigation)
 Includes email input field for password reset requests
 Added "Back to Login" link for easy navigation


<img width="1920" height="845" alt="image" src="https://github.com/user-attachments/assets/45df3b6f-ef2c-41fd-9d1e-8dc354f1e973" />


Closes #153 