### PR TITLE
fix: Fixed password eye toggle not working on login page

### DIFF
--- a/admin-login.html
+++ b/admin-login.html
@@ -126,6 +126,30 @@
   <script src="app.js?v=2.0"></script>
   <script src="darkmode.js?v=2.0"></script>
   <script src="cursor.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      function setupPasswordToggle(toggleSelector, inputId) {
+        const toggleEl = document.querySelector(toggleSelector);
+        const inputEl = document.getElementById(inputId);
+
+        if (toggleEl && inputEl) {
+          toggleEl.addEventListener('click', function () {
+            const type = inputEl.getAttribute('type') === 'password' ? 'text' : 'password';
+            inputEl.setAttribute('type', type);
+            
+            const icon = this.querySelector('i');
+            if (icon) {
+              icon.classList.toggle('fa-eye');
+              icon.classList.toggle('fa-eye-slash');
+            }
+          });
+        }
+      }
+
+      setupPasswordToggle('.toggle-password', 'admin-password');
+      setupPasswordToggle('.toggle-confirm-password', 'admin-confirm-password');
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
# Pull Request — DSCE Clubs

---

## 📌 Related Issue
Fixes #136 

---

## Description of Changes

Fixed password eye toggle not working on login page.

---

## Type of Change
- [x] 🐛 Bug Fix  
- [ ] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [ ] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing

- [x] Tested locally

---
## 📸 Screenshots / Video


https://github.com/user-attachments/assets/3829f920-09e5-4a8b-9fea-ccaf851d197f


---

## ✅ Checklist
- [x] I’ve read the **CONTRIBUTING.md** guidelines.  
- [x] My code follows the project’s conventions.  
- [x] I’ve linked the related issue correctly.  
- [x] I’ve tested my changes locally.  
- [x] I’ve added or updated documentation/comments if needed.  
- [x] My PR title follows the branch & commit naming conventions.  
- [x] My changes introduce no new warnings or errors.  
- [x] I’ve performed a self-review of my work.  

---

## This Pull Request is submitted under SWOC'26.
