### PR TITLE
Title: Fix: Restore broken images and videos on Past Events page

### DIFF
--- a/past-events.html
+++ b/past-events.html
@@ -392,10 +392,9 @@
             <div class="timeline-club">Tech Society</div>
             <div class="timeline-gallery">
               <div class="gallery-scroll">
-                <img src="images/tech-symposium-1.jpg" alt="Tech Symposium" />
-                <img src="images/tech-symposium-2.jpg" alt="Tech Symposium" />
-                <img src="images/tech-symposium-3.jpg" alt="Tech Symposium" />
-                <img src="images/tech-symposium-4.jpg" alt="Tech Symposium" />
+                <img src="https://images.pexels.com/photos/7414020/pexels-photo-7414020.jpeg" alt="Tech Workshop" />
+                <img src="https://images.pexels.com/photos/7793715/pexels-photo-7793715.jpeg" alt="Hackathon" />
+                <img src="https://images.pexels.com/photos/3321793/pexels-photo-3321793.jpeg" alt="Tech Talk" />
               </div>
             </div>
           </div>
@@ -412,11 +411,11 @@
             <div class="timeline-club">Aaleka</div>
             <div class="timeline-gallery">
               <div class="gallery-scroll">
-                <img src="images/art-exhibition-1.jpg" alt="Art Exhibition" />
-                <img src="images/art-exhibition-2.jpg" alt="Art Exhibition" />
-                <img src="images/art-exhibition-3.jpg" alt="Art Exhibition" />
-                <img src="images/art-exhibition-4.jpg" alt="Art Exhibition" />
-              </div>
+              <img src="https://images.pexels.com/photos/12309059/pexels-photo-12309059.jpeg" alt="Art Exhibition" />
+              <img src="https://images.pexels.com/photos/3004109/pexels-photo-3004109.jpeg" alt="Painting" />
+              <img src="https://images.pexels.com/photos/460736/pexels-photo-460736.jpeg" alt="Sculpture" />
+              <img src="https://images.pexels.com/photos/3700250/pexels-photo-3700250.jpeg" alt="Art Exhibition" />
+            </div>
             </div>
           </div>
         </div>
@@ -431,9 +430,9 @@
             <div class="timeline-club">Litsoc</div>
             <div class="timeline-gallery">
               <div class="gallery-scroll">
-                <img src="images/debate-1.jpg" alt="Debate Championship" />
-                <img src="images/debate-2.jpg" alt="Debate Championship" />
-                <img src="images/debate-3.jpg" alt="Debate Championship" />
+                <img src="https://images.pexels.com/photos/8846952/pexels-photo-8846952.jpeg" alt="Debate Stage" />
+                <img src="https://images.pexels.com/photos/7092526/pexels-photo-7092526.jpeg" alt="Preparation" />
+                <img src="https://images.pexels.com/photos/8344905/pexels-photo-8344905.jpeg" alt="Debate Judges" />
               </div>
             </div>
           </div>
@@ -449,9 +448,9 @@
             <div class="timeline-club">Music Society</div>
             <div class="timeline-gallery">
               <div class="gallery-scroll">
-                <img src="images/music-festival-1.jpg" alt="Music Festival" />
-                <img src="images/music-festival-2.jpg" alt="Music Festival" />
-                <img src="images/music-festival-3.jpg" alt="Music Festival" />
+                <img src="https://images.pexels.com/photos/10578433/pexels-photo-10578433.jpeg" alt="Music Festival" />
+                <img src="https://images.pexels.com/photos/1434625/pexels-photo-1434625.jpeg" alt="Singer" />
+                <img src="https://images.pexels.com/photos/1763075/pexels-photo-1763075.jpeg" alt="Music Audience" />
               </div>
             </div>
           </div>
@@ -468,9 +467,9 @@
             <div class="timeline-club">IEDC</div>
             <div class="timeline-gallery">
               <div class="gallery-scroll">
-                <img src="images/science-fair-1.jpg" alt="Science Fair" />
-                <img src="images/science-fair-2.jpg" alt="Science Fair" />
-                <img src="images/science-fair-3.jpg" alt="Science Fair" />
+                <img src="https://images.pexels.com/photos/6248966/pexels-photo-6248966.jpeg" alt="Science Fair" />
+                <img src="https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Science Fair" />
+                <img src="https://images.pexels.com/photos/3194521/pexels-photo-3194521.jpeg" alt="Science Fair" />
               </div>
             </div>
           </div>
@@ -485,8 +484,8 @@
       <div class="highlights-grid">
         <div class="highlight-card">
           <div class="highlight-media">
-            <video controls poster="images/tech-highlight-poster.jpg">
-              <source src="videos/tech-symposium.mp4" type="video/mp4" />
+            <video controls poster="https://images.pexels.com/photos/19451448/pexels-photo-19451448.jpeg">
+             <source src="https://www.pexels.com/download/video/32203300/" type="video/mp4" />
             </video>
           </div>
           <div class="highlight-content">
@@ -504,9 +503,9 @@
         <div class="highlight-card">
           <div class="highlight-media">
             <div class="image-slider">
-              <img src="images/art-gallery.jpg" alt="Art Exhibition" class="active" />
-              <img src="images/art-gallery-2.jpg" alt="Art Exhibition" />
-              <img src="images/art-gallery-3.jpg" alt="Art Exhibition" />
+              <img src="https://images.pexels.com/photos/7763082/pexels-photo-7763082.jpeg" alt="Art Exhibition" class="active" />
+              <img src="https://images.pexels.com/photos/3700250/pexels-photo-3700250.jpeg" alt="Art Exhibition" />
+              <img src="https://images.pexels.com/photos/30150837/pexels-photo-30150837.jpeg" alt="Art Exhibition" />
             </div>
           </div>
           <div class="highlight-content">


### PR DESCRIPTION
# Pull Request — DSCE Clubs

## 📌 Related Issue
Fixes #272 

---

## Description of Changes
This PR addresses the issue where media assets (images and videos) were not displaying on the Past Events page due to missing local files. I have replaced the broken local paths with high-quality, relevant placeholders from sites like Unsplash etc and a reliable sample video link to ensure the UI is fully functional and visually appealing.

---

## Type of Change
- [✔ ] 🐛 Bug Fix  
- [ ] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [ ] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing
Describe the tests you ran to verify your changes.
- [ ✔] Tested locally
- [ ] No tests required
---
## 📸 Screenshots / Video
<img width="1869" height="875" alt="Screenshot 2026-02-28 061646" src="https://github.com/user-attachments/assets/0bb80f81-5706-4656-ac1c-db21fa1cf63c" />
<img width="801" height="737" alt="Screenshot 2026-02-28 061713" src="https://github.com/user-attachments/assets/18a2810f-9cb9-4f1f-84ce-ee1aad978259" />

---

## ✅ Checklist
- [✔ ] I’ve read the **CONTRIBUTING.md** guidelines.  
- [✔ ] My code follows the project’s conventions.  
- [✔ ] I’ve linked the related issue correctly.  
- [✔ ] I’ve tested my changes locally.  
- [✔ ] I’ve added or updated documentation/comments if needed.  
- [ ✔] My PR title follows the branch & commit naming conventions.  
- [✔ ] My changes introduce no new warnings or errors.  
- [✔ ] I’ve performed a self-review of my work.  

