### PR TITLE
fix: Fixed password eye toggle not visible in light mode

### DIFF
--- a/admin-login.html
+++ b/admin-login.html
@@ -96,14 +96,7 @@
           <label for="admin-password">Password</label>
           <div style="position: relative">
             <input type="password" id="admin-password" required placeholder="Enter password" />
-            <span class="toggle-password" style="
-                  position: absolute;
-                  right: 15px;
-                  top: 50%;
-                  transform: translateY(-50%);
-                  cursor: pointer;
-                  color: white;
-                ">
+            <span class="toggle-password">
               <i class="fas fa-eye"></i>
             </span>
           </div>
@@ -112,14 +105,7 @@
           <label for="admin-confirm-password">Confirm Password</label>
           <div style="position: relative">
             <input type="password" id="admin-confirm-password" placeholder="Confirm password" />
-            <span class="toggle-confirm-password" style="
-                  position: absolute;
-                  right: 15px;
-                  top: 50%;
-                  transform: translateY(-50%);
-                  cursor: pointer;
-                  color: white;
-                "><i class="fas fa-eye"></i></span>
+            <span class="toggle-confirm-password"><i class="fas fa-eye"></i></span>
           </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -3192,7 +3192,8 @@ body.light-mode .dot:hover {
   transition: var(--transition);
 }
 
-.toggle-password:hover {
+.toggle-password,
+.toggle-confirm-password {
   color: var(--accent-color);
 }
 


### PR DESCRIPTION
# Pull Request — DSCE Clubs

---

## 📌 Related Issue
Fixes #335 

---

## Description of Changes

Fixed password eye toggle not visible in light mode.

---

## Type of Change
- [x] 🐛 Bug Fix  
- [ ] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [x] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing
Describe the tests you ran to verify your changes.
- [x] Tested locally
- [ ] No tests required
---
## 📸 Screenshots / Video

<img width="1919" height="969" alt="Screenshot 2026-03-01 014402" src="https://github.com/user-attachments/assets/bc678fab-8695-4bb7-9e5d-9c6ac475eba5" />


---

## ✅ Checklist
- [x] I’ve read the **CONTRIBUTING.md** guidelines.  
- [x] My code follows the project’s conventions.  
- [x] I’ve linked the related issue correctly.  
- [x] I’ve tested my changes locally.  
- [x] I’ve added or updated documentation/comments if needed.  
- [x] My PR title follows the branch & commit naming conventions.  
- [x] My changes introduce no new warnings or errors.  
- [x] I’ve performed a self-review of my work.  

---

## This Pull Request is submitted under SWOC'26.
