### PR TITLE
fix: improve mobile nav text visibility in light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -6832,3 +6832,19 @@ body.oled-mode .forum-stats-bar {
     height: 42px;
   }
 }
+
+/* ✅ LIGHT MODE MOBILE NAV FIX */
+@media (max-width: 768px) {
+  body.light-mode .cosmic-nav .nav-links a {
+    color: #2d3436;
+  }
+
+  body.light-mode .nav-hamburger .line {
+    background: #2d3436;
+  }
+
+  body.light-mode .nav-links a {
+    color: #ffffff !important;
+  }
+
+}


### PR DESCRIPTION
# Pull Request — DSCE Clubs

Thank you for contributing to **DSCE Clubs: Centralized Club Management Platform**!  
Please fill out the following details to help us review your PR efficiently.

---

## 📌 Related Issue
Fixes #329 

---

## Description of Changes
Improved text visibility of the mobile navigation menu in light mode.
# Key changes:
- Scoped light-mode dark text styling to the desktop navbar only.
- Ensured mobile menu keeps the cosmic dark background.
- Forced readable white text for nav links on mobile in light mode.
- Maintained existing dark-mode behavior.
This resolves the contrast issue where mobile nav links were not visible in light mode.


---

## Type of Change
- [✅] 🐛 Bug Fix  
- [ ] 🔧 Feature Modification  
- [ ] ✨ New Feature  
- [ ] 🧹 Maintenance / Cleanup / Documentation Update  
- [✅] 🎨 UI/UX or Design Update  
- [ ] 📘 Resource / Content Addition  
- [ ] Other  (please describe):

---
## Testing
Describe the tests you ran to verify your changes.
- [✅] Tested locally
- [ ] No tests required
---
## 📸 Screenshots / Video
Before:
<img width="1512" height="982" alt="Issue" src="https://github.com/user-attachments/assets/9f90a455-96e5-4c6a-971e-46f8bb4df874" />
After:
<img width="1512" height="982" alt="Screenshot 2026-03-01 at 10 41 51 AM" src="https://github.com/user-attachments/assets/d5ed035a-0850-4cd9-857e-856b79623865" />


---

## ✅ Checklist
- [✅] I’ve read the **CONTRIBUTING.md** guidelines.  
- [✅] My code follows the project’s conventions.  
- [✅] I’ve linked the related issue correctly.  
- [✅] I’ve tested my changes locally.  
- [✅] I’ve added or updated documentation/comments if needed.  
- [✅] My PR title follows the branch & commit naming conventions.  
- [✅] My changes introduce no new warnings or errors.  
- [✅] I’ve performed a self-review of my work.  

---

## 💬 Additional Notes
- Please assign this Pull Request under SWoC26 and give easy/medium/hard and Beginner/Intermediate/Advanced level also.
